### PR TITLE
Minor tweak to ensure build with latest OFW

### DIFF
--- a/NRF24ChannelScanner/nrf24channelscanner.c
+++ b/NRF24ChannelScanner/nrf24channelscanner.c
@@ -7,7 +7,6 @@
 #include <notification/notification_messages.h>
 #include <nrf24.h>
 #include "nrf24channelscanner_icons.h"
-#include <assets_icons.h>
 
 const uint8_t num_channels = 128;
 static uint8_t nrf24values[128] = {0}; //to store channel data

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Thanks for the image: [Sil333033](https://github.com/Sil333033)
 
 
 # Pinout from from NoComp/Frog
-<img src="https://media.discordapp.net/attachments/937479784726949900/994495234618687509/unknown.png?width=567&height=634">
+<img width="567" height="634" alt="image" src="https://github.com/user-attachments/assets/21f74f21-119d-4890-a736-ba4eda6ecb3a" />
 
 # Mousejacker / NRF24 pinout by UberGuidoZ
 2/A7 on FZ goes to MOSI/6 on nrf24l01<br>
@@ -66,3 +66,4 @@ The 3.3 uF to 10 uF will respond to slow freq changes while the 0.1 uF will resp
 Used images and some text from this repo: https://raw.githubusercontent.com/RogueMaster/flipperzero-firmware-wPlugins/420/documentation/NRF24.md
 Used some code from this repo: https://github.com/Flipper-XFW/Xtreme-Firmware
 Thanks for them for their work!
+


### PR DESCRIPTION
Building the current version with the latest OFW results in an error because the included icons clash with the OFW headers: 
```console
In file included from applications_user/NRF24ChannelScanner/nrf24channelscanner.c:10:
build/f7-firmware-D/assets/compiled/assets_icons.h:36:19: error: redundant redeclaration of 'I_Ok_btn_9x9' [-Werror=redundant-decls]
   36 | extern const Icon I_Ok_btn_9x9;
```
This can be fixed by not importing the entire assets_icons.h with the clashing declarations.

I have tested that the resulting FAP works on my Flipper Zero running the latest Firmware. 